### PR TITLE
feat: Optimize the prompt after the copy command

### DIFF
--- a/hubcmdui/web/index.html
+++ b/hubcmdui/web/index.html
@@ -221,6 +221,21 @@
                 display: flex;
             }
         }
+        .notification {
+            display: none;
+            position: absolute;
+            top: 15px; /* Adjust the position as needed */
+            left: 85%;
+            transform: translateX(-50%);
+            background-color: #333;
+            color: #fff;
+            padding: 10px 20px;
+            border-radius: 5px;
+            font-size: 14px;
+            opacity: 0;
+            transition: opacity 0.5s ease-in-out;
+            z-index: 1000;
+        }
     </style>
 </head>
 <body>
@@ -300,7 +315,9 @@
                 cmdDiv.className = 'step';
                 cmdDiv.innerHTML = `
                     <h3>${index + 1}. ${command.title}</h3>
-                    <pre><code>${command.cmd}</code><button class="copy-btn" onclick="copyToClipboard('${command.cmd}')">复制</button></pre>
+                    <pre><code>${command.cmd}</code>
+                    <div id="copyNotification${index}" class="notification">已复制!</div>
+                    <button class="copy-btn" onclick="copyToClipboard('${command.cmd}', 'copyNotification${index}')">复制</button></pre>
                 `;
                 container.appendChild(cmdDiv);
             });
@@ -312,9 +329,19 @@
         }
 
         // 复制命令到剪贴板
-        function copyToClipboard(text) {
+        function copyToClipboard(text, notificationId) {
             navigator.clipboard.writeText(text).then(() => {
-                alert('命令已复制到剪贴板');
+                var notification = document.getElementById(notificationId);
+                notification.style.display = 'block';
+                notification.style.opacity = '1';
+
+                // 在2秒后隐藏提示
+                setTimeout(function() {
+                    notification.style.opacity = '0';
+                    setTimeout(function() {
+                        notification.style.display = 'none';
+                    }, 500);
+                }, 2000);
             }, (err) => {
                 console.error('无法复制文本: ', err);
             });

--- a/hubcmdui/web/index.html
+++ b/hubcmdui/web/index.html
@@ -224,14 +224,14 @@
         .notification {
             display: none;
             position: absolute;
-            top: 15px; /* Adjust the position as needed */
-            left: 85%;
+            top: 7px; /* Adjust the position as needed */
+            left: 87%;
             transform: translateX(-50%);
             background-color: #333;
             color: #fff;
-            padding: 10px 20px;
+            padding: 5px 10px;
             border-radius: 5px;
-            font-size: 14px;
+            font-size: 12px;
             opacity: 0;
             transition: opacity 0.5s ease-in-out;
             z-index: 1000;
@@ -314,10 +314,7 @@
                 const cmdDiv = document.createElement('div');
                 cmdDiv.className = 'step';
                 cmdDiv.innerHTML = `
-                    <h3>${index + 1}. ${command.title}</h3>
-                    <pre><code>${command.cmd}</code>
-                    <div id="copyNotification${index}" class="notification">已复制!</div>
-                    <button class="copy-btn" onclick="copyToClipboard('${command.cmd}', 'copyNotification${index}')">复制</button></pre>
+                    <h3>${index + 1}. ${command.title}</h3> <pre><code>${command.cmd}</code><div id="copyNotification${index}" class="notification">已复制!</div><button class="copy-btn" onclick="copyToClipboard('${command.cmd}', 'copyNotification${index}')">复制</button></pre>
                 `;
                 container.appendChild(cmdDiv);
             });


### PR DESCRIPTION
###  以前的提示
> 复制完后需要每次都点击确定，才能在页面上进行其他操作，很是麻烦
<img width="687" alt="image" src="https://github.com/user-attachments/assets/a7714da9-69e5-42fe-bf69-be58cfb466f1">

### 优化后的提示
> 点击完后，弹出一个小框，2s后自动消失，弹出框后也不会影响在页面上的其他操作
体验地址：https://hubcmd.depix.cn/
<img width="1289" alt="image" src="https://github.com/user-attachments/assets/386fb2d2-f55c-4f73-ab01-4b617c5e3f51">
