### PR TITLE
fix: 修复HubCMD-UI的docker-compose.yaml环境配置错误

### DIFF
--- a/hubcmdui/docker-compose.yaml
+++ b/hubcmdui/docker-compose.yaml
@@ -4,7 +4,7 @@ services:
     container_name: hubcmd-ui
     image: dqzboy/hubcmd-ui:latest
     restart: always
-    environment:
+    # environment:
       # HTTP代理配置（可选）
       #- HTTP_PROXY=http://proxy.example.com:8080
       #- HTTPS_PROXY=https://proxy.example.com:8080


### PR DESCRIPTION
- 注释掉空的environment配置节，解决"environment must be a mapping"验证错误
- 修复安装脚本中HubCMD-UI服务启动失败的问题